### PR TITLE
Query KittenSwap LPs directly from HyperEVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# SUI Liquidity Provider Tracker
+# Hyperliquid Kittenswap LP Tracker
 
-Welcome to the **SUI Liquidity Provider Tracker** project!  
-This app helps you track your SUI LP (Liquidity Provider) positions, claim fees, and portfolio performance in real time.
+Welcome to the **Hyperliquid Kittenswap LP Tracker** project!
+This app helps you inspect Kittenswap liquidity provider (LP) positions for any Hyperliquid wallet.
 
 ---
 
 ## About
 
-This project is a work-in-progress tool for tracking SUI liquidity provider activity, including:
+This project is a work-in-progress tool for tracking Hyperliquid Kittenswap liquidity provider activity, including:
 
-- **LP Positions**: See your deposits, withdrawals, and current values.
-- **Claim Fees**: Track all claim fees, with breakdowns by token and time period.
-- **Impermanent Loss**: Visualize your IL and portfolio changes.
-- **Exclusion Feature**: Exclude specific transactions from calculations for custom analytics.
+- **LP Positions**: View all detected Kittenswap pools for a wallet and their USD values.
+- **Token Exposure**: See the token amounts that make up each LP position.
+- **Fees**: Inspect any accrued or claimable fees if Hyperliquid exposes them.
+- **Timestamps**: Check when each position was last updated according to the payload data.
 
 The frontend is built using [TailAdmin](https://tailadmin.com) (Next.js + Tailwind CSS), providing a modern, responsive dashboard UI.
 
@@ -33,33 +33,38 @@ If you find bugs or have suggestions, please open an issue or feedback on this r
 
 ---
 
-## Demo
-
-*Coming soon!*
-
----
-
 ## How to Run
 
 1. **Clone the repo:**
     ```bash
-    git clone https://github.com/your-username/sui-lp-tracker.git
-    cd sui-lp-tracker
+    git clone https://github.com/your-username/kitten-lp-tracker.git
+    cd kitten-lp-tracker
     ```
 
 2. **Install dependencies:**
     ```bash
     npm install
-    # or
-    yarn install
     ```
 
-3. **Start the development server:**
+3. **(Optional) Configure on-chain RPC settings:**
+   The tracker now decodes KittenSwap Algebra CLMM NFTs directly from HyperEVM. You can tweak the RPC and log scanning behaviour in `.env.local` if needed:
+    ```bash
+    # Override the default HyperEVM RPC endpoint
+    HYPEREVM_RPC=https://rpc.hyperliquid.xyz/evm
+
+    # (Optional) Optimise transfer log scanning when enumeration fails
+    START_BLOCK=0
+    CHUNK_SPAN=800
+    ```
+   The defaults work for most setups, but operators running their own archival RPCs can lower `CHUNK_SPAN` or raise `START_BLOCK` to improve responsiveness.
+
+4. **Start the development server:**
     ```bash
     npm run dev
-    # or
-    yarn dev
     ```
+
+5. **Open the tracker:**
+   Visit [http://localhost:3000/admin](http://localhost:3000/admin) and enter any Hyperliquid wallet address to fetch its Kittenswap LP positions.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "free-nextjs-admin-dashboard",
-  "version": "2.0.2",
+  "name": "sui-lp-tracker",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "free-nextjs-admin-dashboard",
-      "version": "2.0.2",
+      "name": "sui-lp-tracker",
+      "version": "1.4.9",
       "dependencies": {
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
@@ -15,6 +15,7 @@
         "@fullcalendar/react": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@mysten/sui.js": "^0.54.1",
+        "@noble/hashes": "^1.8.0",
         "@react-jvectormap/core": "^1.0.4",
         "@react-jvectormap/world": "^1.1.2",
         "@solana/web3.js": "^1.98.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mysten/sui.js": "^0.54.1",
     "@react-jvectormap/core": "^1.0.4",
     "@react-jvectormap/world": "^1.1.2",
+    "@noble/hashes": "^1.8.0",
     "@solana/web3.js": "^1.98.2",
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/postcss": "^4.0.9",

--- a/src/app/(admin)/page.tsx
+++ b/src/app/(admin)/page.tsx
@@ -1,128 +1,261 @@
-'use client'
+"use client";
 
-import React, { useState } from "react";
-import { EcommerceMetrics } from "@/components/ecommerce/SummaryCard";
-import MonthlyTarget from "@/components/ecommerce/MonthlyTarget";
-import RecentOrders from "@/components/ecommerce/TransactionDetail";
+import React, { useMemo, useState } from "react";
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 
-// Transaction type for LPResult
-interface Transaction {
-  type: "add" | "remove";
-  txUrl: string;
-  initialWorth: number;
-  currentWorth: number;
-  amounts: Record<string, number>;
-  timestamp: string;
-}
-
-// LPResult type
-interface LPResult {
-  name: string;
-  transactions: Transaction[];
-}
-
-// LP Range type
-interface LPRange {
+interface KittenswapPosition {
   poolName: string;
-  lower: number;
-  upper: number;
+  totalValueUsd: number;
+  sharePercent?: number;
+  tokenAmounts: Record<string, number>;
+  accruedFeesUsd?: number;
+  lastUpdated?: string;
 }
 
-// ClaimFee transaction type
-interface ClaimFeeTransaction {
-  poolName: string;
-  txUrl: string;
-  amounts: Record<string, string>;
-  timestamp: string;
-  currentWorthUSD: number;
-  initialWorthUSD: number;
+interface ApiResponse {
+  protocol?: string;
+  network?: string;
+  positions?: KittenswapPosition[];
+  error?: string;
+  details?: string;
 }
 
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
 
-export default function Ecommerce() {
-  // --- LP Tracker logic ---
+const percentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
+
+export default function HyperliquidKittenswapPage() {
   const [walletAddress, setWalletAddress] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [lpResults, setLpResults] = useState<LPResult[]>([]);
-  const [claimFees, setClaimFees] = useState<ClaimFeeTransaction[]>([]);
-  const [lpRanges, setLpRanges] = useState<LPRange[]>([]);
+  const [positions, setPositions] = useState<KittenswapPosition[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+
+  const isValidWallet = (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value.trim());
 
   const handleTrackWallet = async () => {
-    if (!walletAddress) {
-      alert("Please enter a wallet address.");
+    if (!walletAddress.trim()) {
+      setError("Please enter a wallet address.");
       return;
     }
+
+    if (!isValidWallet(walletAddress)) {
+      setError("Wallet must be a valid 0x-prefixed Hyperliquid address.");
+      return;
+    }
+
     setIsLoading(true);
+    setError(null);
     try {
-      const response = await fetch("/api/sui", {
+      const response = await fetch("/api/hyperliquid/kittenswap", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ walletAddress }),
+        body: JSON.stringify({ walletAddress: walletAddress.trim() }),
       });
-      
-      const data = await response.json();
-      
-      setLpResults(data?.transactions ?? []);
-      setClaimFees(data?.claimFees ?? []);
-      setLpRanges(data?.lpRanges ?? []);
+
+      const data: ApiResponse = await response.json();
+
+      if (!response.ok) {
+        setPositions([]);
+        setLastUpdated(null);
+        setError(data?.error || data?.details || "Failed to fetch LP data.");
+        return;
+      }
+
+      setPositions(data.positions ?? []);
+      setLastUpdated(new Date().toISOString());
     } catch (err) {
-      alert(err);
+      setError(
+        err instanceof Error ? err.message : "Unable to fetch LP information."
+      );
+      setPositions([]);
+      setLastUpdated(null);
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   };
-  
+
+  const totalValueUsd = useMemo(
+    () => positions.reduce((sum, position) => sum + (position.totalValueUsd || 0), 0),
+    [positions]
+  );
+
+  const totalAccruedFeesUsd = useMemo(
+    () => positions.reduce((sum, position) => sum + (position.accruedFeesUsd || 0), 0),
+    [positions]
+  );
+
+  const tokenTotals = useMemo(() => {
+    const totals: Record<string, number> = {};
+    for (const position of positions) {
+      for (const [symbol, amount] of Object.entries(position.tokenAmounts)) {
+        if (!Number.isFinite(amount)) continue;
+        totals[symbol] = (totals[symbol] || 0) + amount;
+      }
+    }
+    return totals;
+  }, [positions]);
+
   return (
-    <div className="grid grid-cols-12 gap-4 md:gap-6">
-      <div className="col-span-12">
-        {/* Wallet Address Input */}
-        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+        <h1 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          Kittenswap LP Tracker (Hyperliquid)
+        </h1>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          Enter a Hyperliquid wallet address to fetch active Kittenswap LP positions.
+        </p>
+        <div className="mt-6 flex flex-col gap-4 sm:flex-row">
           <input
             name="walletAddress"
             type="text"
             value={walletAddress}
-            onChange={(e) => setWalletAddress(e.target.value)}
-            placeholder="Enter SUI wallet address..."
-            className="flex-grow border rounded-md py-2 px-4  dark:text-gray-300"
+            onChange={(event) => setWalletAddress(event.target.value)}
+            placeholder="0x..."
+            className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
           />
           <button
+            type="button"
             onClick={handleTrackWallet}
             disabled={isLoading}
-            className="bg-brand-500 text-white px-6 py-2 rounded-md"
+            className="rounded-md bg-brand-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-70"
           >
-            {isLoading ? "Loading..." : "Track LP"}
+            {isLoading ? "Checking..." : "Check Positions"}
           </button>
         </div>
-      </div>
+        {error && (
+          <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+            {error}
+          </div>
+        )}
+        {lastUpdated && !error && (
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            Last refreshed: {new Date(lastUpdated).toLocaleString()}
+          </p>
+        )}
+      </section>
 
-      <div className="col-span-12 space-y-6 xl:col-span-7">
-        <EcommerceMetrics lpResults={{ sui: lpResults }}  />
-      </div>
+      <section className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Total Value</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white/90">
+            {currencyFormatter.format(totalValueUsd)}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Accrued Fees</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white/90">
+            {currencyFormatter.format(totalAccruedFeesUsd)}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Pools</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white/90">
+            {positions.length}
+          </p>
+        </div>
+      </section>
 
-      <div className="col-span-12 xl:col-span-5">
-        {/* Pass totalClaimFee to MonthlyTarget */}
-        <MonthlyTarget lpResults={lpResults} claimFees={claimFees.map(fee => ({
-          ...fee,
-          initializeWorthUSD: fee.initialWorthUSD
-        }))} />
-      </div>
-      
-      <div className="col-span-12">
-        <RecentOrders
-          lpResults={{
-            sui: lpResults.map(pool => ({
-              ...pool,
-              transactions: pool.transactions.map(tx => ({
-                ...tx,
-                amounts: Object.fromEntries(
-                  Object.entries(tx.amounts).map(([k, v]) => [k, v.toString()])
-                ),
-              })),
-            })),
-          }}
-          lpRanges={lpRanges}
-          isLoading={isLoading}
-        />
-      </div>
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+          Token Exposure
+        </h2>
+        {positions.length === 0 ? (
+          <p className="mt-4 text-sm text-gray-600 dark:text-gray-400">
+            No Kittenswap LP positions found for this wallet.
+          </p>
+        ) : (
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Object.entries(tokenTotals)
+              .sort(([, amountA], [, amountB]) => amountB - amountA)
+              .map(([symbol, amount]) => (
+              <div
+                key={symbol}
+                className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900/50 dark:text-gray-200"
+              >
+                <p className="font-medium">{symbol}</p>
+                <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-white/90">
+                  {amount.toLocaleString(undefined, { maximumFractionDigits: 6 })}
+                </p>
+              </div>
+              ))}
+          </div>
+        )}
+      </section>
+
+      {positions.length > 0 && (
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-white/[0.03]">
+          <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+            Kittenswap LP Positions
+          </h2>
+          <div className="mt-4 overflow-x-auto">
+            <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+              <TableHeader className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+                <TableRow>
+                  <TableCell isHeader className="px-4 py-3">Pool</TableCell>
+                  <TableCell isHeader className="px-4 py-3">Total Value</TableCell>
+                  <TableCell isHeader className="px-4 py-3">Share</TableCell>
+                  <TableCell isHeader className="px-4 py-3">Accrued Fees</TableCell>
+                  <TableCell isHeader className="px-4 py-3">Token Amounts</TableCell>
+                  <TableCell isHeader className="px-4 py-3">Last Update</TableCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {positions.map((position) => (
+                  <TableRow
+                    key={`${position.poolName}-${position.lastUpdated ?? "unknown"}`}
+                    className="text-sm text-gray-800 dark:text-gray-200"
+                  >
+                    <TableCell className="px-4 py-3 font-medium">{position.poolName}</TableCell>
+                    <TableCell className="px-4 py-3">
+                      {currencyFormatter.format(position.totalValueUsd ?? 0)}
+                    </TableCell>
+                   <TableCell className="px-4 py-3">
+                      {position.sharePercent !== undefined
+                        ? percentFormatter.format(
+                            position.sharePercent > 1
+                              ? position.sharePercent / 100
+                              : position.sharePercent
+                          )
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="px-4 py-3">
+                      {position.accruedFeesUsd !== undefined
+                        ? currencyFormatter.format(position.accruedFeesUsd)
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="px-4 py-3">
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(position.tokenAmounts).map(([symbol, amount]) => (
+                          <span
+                            key={`${position.poolName}-${symbol}`}
+                            className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                          >
+                            {symbol}: {amount.toLocaleString(undefined, { maximumFractionDigits: 6 })}
+                          </span>
+                        ))}
+                        {Object.keys(position.tokenAmounts).length === 0 && <span>-</span>}
+                      </div>
+                    </TableCell>
+                    <TableCell className="px-4 py-3">
+                      {position.lastUpdated
+                        ? new Date(position.lastUpdated).toLocaleString()
+                        : "-"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/app/api/hyperliquid/kittenswap/providers.ts
+++ b/src/app/api/hyperliquid/kittenswap/providers.ts
@@ -1,0 +1,21 @@
+import {
+  fetchOnchainKittenswapPositions,
+  type Address,
+  type AttemptLog,
+  type KittenswapPosition,
+} from "./utils";
+
+interface FetchOptions {
+  walletAddress: Address;
+}
+
+interface FetchOutcome {
+  positions: KittenswapPosition[];
+  source: string;
+  attempts: AttemptLog[];
+}
+
+export async function fetchKittenswapData({ walletAddress }: FetchOptions): Promise<FetchOutcome> {
+  const { positions, source, attempts } = await fetchOnchainKittenswapPositions(walletAddress);
+  return { positions, source, attempts };
+}

--- a/src/app/api/hyperliquid/kittenswap/route.ts
+++ b/src/app/api/hyperliquid/kittenswap/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { fetchKittenswapData } from "./providers";
+import { isValidWalletAddress, type Address } from "./utils";
+
+interface RequestBody {
+  walletAddress?: string;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body: RequestBody = await request.json();
+    const walletAddress = body.walletAddress;
+
+    if (!isValidWalletAddress(walletAddress)) {
+      return NextResponse.json(
+        { error: "A valid 0x-prefixed wallet address is required." },
+        { status: 400 }
+      );
+    }
+
+    const { positions, source, attempts } = await fetchKittenswapData({
+      walletAddress: walletAddress as Address,
+    });
+
+    return NextResponse.json({
+      protocol: "Kittenswap",
+      network: "Hyperliquid",
+      source,
+      attempts,
+      positions,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      {
+        error: "Unable to process request.",
+        details: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/hyperliquid/kittenswap/utils.ts
+++ b/src/app/api/hyperliquid/kittenswap/utils.ts
@@ -1,0 +1,535 @@
+import { keccak_256 } from "@noble/hashes/sha3";
+import { utf8ToBytes } from "@noble/hashes/utils";
+
+export type Address = `0x${string}`;
+export type Hex = `0x${string}`;
+
+export interface KittenswapPosition {
+  poolName: string;
+  totalValueUsd: number;
+  sharePercent?: number;
+  tokenAmounts: Record<string, number>;
+  accruedFeesUsd?: number;
+  lastUpdated?: string;
+}
+
+export interface AttemptLog {
+  step: string;
+  success: boolean;
+  details?: string;
+  error?: string;
+}
+
+const RPC_URL = process.env.HYPEREVM_RPC || "https://rpc.hyperliquid.xyz/evm";
+
+const NONFUNGIBLE_POSITION_MANAGER: Address = "0x9ea4459c8DefBF561495d95414b9CF1E2242a3E2";
+const ALGEBRA_FACTORY: Address = "0x5f95E92c338e6453111Fc55ee66D4AafccE661A7";
+const FARMING_CENTER: Address = "0x211BD8917d433B7cC1F4497AbA906554Ab6ee479";
+
+const START_BLOCK = BigInt(process.env.START_BLOCK || "0");
+const CHUNK_SPAN = BigInt(process.env.CHUNK_SPAN || "800");
+
+const TRANSFER_TOPIC: Hex =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const MAX_U128 = (1n << 128n) - 1n;
+
+const SELECTORS = {
+  balanceOf: methodSelector("balanceOf(address)"),
+  tokenOfOwnerByIndex: methodSelector("tokenOfOwnerByIndex(address,uint256)"),
+  positions: methodSelector("positions(uint256)"),
+  globalState: methodSelector("globalState()"),
+  decimals: methodSelector("decimals()"),
+  symbol: methodSelector("symbol()"),
+  poolByPair: methodSelector("poolByPair(address,address)"),
+  deposits: methodSelector("deposits(uint256)"),
+};
+
+function methodSelector(signature: string) {
+  return Buffer.from(keccak_256(utf8ToBytes(signature))).toString("hex").slice(0, 8);
+}
+
+function padHex(value: string, length = 64) {
+  return value.padStart(length, "0");
+}
+
+function encodeAddress(address: Address) {
+  return padHex(address.toLowerCase().replace(/^0x/, ""));
+}
+
+function encodeUint(value: bigint) {
+  return padHex(value.toString(16));
+}
+
+function hexToBigInt(hex: string) {
+  return hex ? BigInt(`0x${hex}`) : 0n;
+}
+
+function hexToAddress(word: string): Address {
+  return (`0x${word.slice(-40)}` as Address).toLowerCase() as Address;
+}
+
+function hexToSigned(word: string, bits: number) {
+  const mask = (1n << BigInt(bits)) - 1n;
+  const raw = BigInt(`0x${word}`) & mask;
+  const signBit = 1n << (BigInt(bits) - 1n);
+  const signed = raw & signBit ? raw - (mask + 1n) : raw;
+  return Number(signed);
+}
+
+function chunkWords(data: Hex) {
+  const hex = data.replace(/^0x/, "");
+  const words: string[] = [];
+  for (let i = 0; i < hex.length; i += 64) {
+    words.push(hex.slice(i, i + 64).padEnd(64, "0"));
+  }
+  return words;
+}
+
+function decodeString(data: Hex) {
+  const hex = data.replace(/^0x/, "");
+  if (!hex) return "";
+  const offset = Number(hexToBigInt(hex.slice(0, 64)));
+  const length = Number(hexToBigInt(hex.slice(offset * 2, offset * 2 + 64)));
+  const start = offset * 2 + 64;
+  const end = start + length * 2;
+  const slice = hex.slice(start, end);
+  return Buffer.from(slice, "hex").toString("utf8").replace(/\u0000+$/g, "");
+}
+
+async function rpcCall(method: string, params: unknown[]) {
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RPC ${method} failed with status ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message || `RPC ${method} error`);
+  }
+
+  return payload.result;
+}
+
+async function ethCall(address: Address, data: Hex) {
+  return (await rpcCall("eth_call", [
+    { to: address, data },
+    "latest",
+  ])) as Hex;
+}
+
+async function getBlockNumber() {
+  const result = (await rpcCall("eth_blockNumber", [])) as Hex;
+  return BigInt(result);
+}
+
+async function getLogs(address: Address, fromBlock: bigint, toBlock: bigint, topics: (Hex | null)[]) {
+  return (await rpcCall("eth_getLogs", [
+    {
+      address,
+      fromBlock: `0x${fromBlock.toString(16)}`,
+      toBlock: `0x${toBlock.toString(16)}`,
+      topics,
+    },
+  ])) as { topics: Hex[] }[];
+}
+
+async function readBalanceOf(wallet: Address) {
+  const data = `0x${SELECTORS.balanceOf}${encodeAddress(wallet)}` as Hex;
+  const response = await ethCall(NONFUNGIBLE_POSITION_MANAGER, data);
+  return hexToBigInt(response.replace(/^0x/, ""));
+}
+
+async function readTokenOfOwnerByIndex(wallet: Address, index: bigint) {
+  const data =
+    `0x${SELECTORS.tokenOfOwnerByIndex}${encodeAddress(wallet)}${encodeUint(index)}` as Hex;
+  const response = await ethCall(NONFUNGIBLE_POSITION_MANAGER, data);
+  return hexToBigInt(response.replace(/^0x/, ""));
+}
+
+async function readPositions(tokenId: bigint) {
+  const data = `0x${SELECTORS.positions}${encodeUint(tokenId)}` as Hex;
+  const response = await ethCall(NONFUNGIBLE_POSITION_MANAGER, data);
+  const words = chunkWords(response);
+
+  const base = {
+    token0: hexToAddress(words[2]),
+    token1: hexToAddress(words[3]),
+    tickLower: hexToSigned(words[4], 24),
+    tickUpper: hexToSigned(words[5], 24),
+    liquidity: hexToBigInt(words[6]),
+    owed0: hexToBigInt(words[9] ?? "0"),
+    owed1: hexToBigInt(words[10] ?? "0"),
+  };
+
+  // Some variants include pool at index 4.
+  if (!plausible(base.tickLower, base.tickUpper, base.liquidity) && words.length >= 12) {
+    return {
+      token0: hexToAddress(words[2]),
+      token1: hexToAddress(words[3]),
+      tickLower: hexToSigned(words[5], 24),
+      tickUpper: hexToSigned(words[6], 24),
+      liquidity: hexToBigInt(words[7]),
+      owed0: hexToBigInt(words[10] ?? "0"),
+      owed1: hexToBigInt(words[11] ?? "0"),
+    };
+  }
+
+  return base;
+}
+
+async function readGlobalState(pool: Address) {
+  const data = `0x${SELECTORS.globalState}` as Hex;
+  const response = await ethCall(pool, data);
+  const words = chunkWords(response);
+  const tick = hexToSigned(words[1], 24);
+  return { currentTick: tick };
+}
+
+async function readDecimals(token: Address) {
+  const data = `0x${SELECTORS.decimals}` as Hex;
+  const response = await ethCall(token, data);
+  return Number(hexToBigInt(response.replace(/^0x/, "")));
+}
+
+async function readSymbol(token: Address) {
+  const data = `0x${SELECTORS.symbol}` as Hex;
+  const response = await ethCall(token, data);
+  const raw = response.replace(/^0x/, "");
+  if (raw.length <= 64) {
+    const buffer = Buffer.from(raw.slice(-64), "hex");
+    const text = buffer.toString("utf8").replace(/\u0000+$/g, "");
+    return text || "TKN";
+  }
+  const decoded = decodeString(response);
+  return decoded || "TKN";
+}
+
+async function readPoolByPair(token0: Address, token1: Address) {
+  const data =
+    `0x${SELECTORS.poolByPair}${encodeAddress(token0)}${encodeAddress(token1)}` as Hex;
+  const response = await ethCall(ALGEBRA_FACTORY, data);
+  const decoded = hexToAddress(response.replace(/^0x/, ""));
+  if (decoded === "0x0000000000000000000000000000000000000000") {
+    throw new Error("Pool address not found for token pair");
+  }
+  return decoded;
+}
+
+async function readDepositPool(tokenId: bigint) {
+  const data = `0x${SELECTORS.deposits}${encodeUint(tokenId)}` as Hex;
+  try {
+    const response = await ethCall(FARMING_CENTER, data);
+    const words = chunkWords(response);
+    return hexToAddress(words[3]);
+  } catch {
+    return undefined;
+  }
+}
+
+function toTopicAddress(address: Address): Hex {
+  return (`0x${padHex(address.toLowerCase().replace(/^0x/, ""), 64)}` as Hex).toLowerCase() as Hex;
+}
+
+function plausible(tickLower: number, tickUpper: number, liquidity: bigint) {
+  const abs = (n: number) => (n < 0 ? -n : n);
+  return abs(tickLower) < 3_000_000 && abs(tickUpper) < 3_000_000 && liquidity > 0n && liquidity <= MAX_U128;
+}
+
+function tickToPrice(tick: number) {
+  return Math.pow(1.0001, tick);
+}
+
+function tickToSqrtPrice(tick: number) {
+  return Math.sqrt(tickToPrice(tick));
+}
+
+function amountsFromLiquidity(liquidity: bigint, currentTick: number, tickLower: number, tickUpper: number) {
+  let sqrtP = tickToSqrtPrice(currentTick);
+  let sqrtA = tickToSqrtPrice(tickLower);
+  let sqrtB = tickToSqrtPrice(tickUpper);
+  if (sqrtA > sqrtB) [sqrtA, sqrtB] = [sqrtB, sqrtA];
+
+  if (!Number.isFinite(sqrtP) || sqrtP <= 0) {
+    sqrtP = (sqrtA + sqrtB) / 2;
+  }
+
+  const L = Number(liquidity);
+  if (!Number.isFinite(L) || L <= 0) {
+    return { amount0: 0, amount1: 0 };
+  }
+
+  if (sqrtP <= sqrtA) {
+    return { amount0: L * ((sqrtB - sqrtA) / (sqrtA * sqrtB)), amount1: 0 };
+  }
+
+  if (sqrtP >= sqrtB) {
+    return { amount0: 0, amount1: L * (sqrtB - sqrtA) };
+  }
+
+  return {
+    amount0: L * ((sqrtB - sqrtP) / (sqrtP * sqrtB)),
+    amount1: L * (sqrtP - sqrtA),
+  };
+}
+
+function isStable(symbol: string) {
+  const upper = symbol.toUpperCase();
+  return ["USD", "USDT", "USDC", "DAI", "USDE"].some((needle) => upper.includes(needle));
+}
+
+function clampPrecision(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  const abs = Math.abs(value);
+  if (abs >= 1e9) {
+    return Number(value.toExponential(4));
+  }
+  return Number(value.toFixed(6));
+}
+
+async function tryEnumerableTokenIds(wallet: Address) {
+  try {
+    const balance = await readBalanceOf(wallet);
+    const ids: number[] = [];
+    for (let i = 0n; i < balance; i++) {
+      const tokenId = await readTokenOfOwnerByIndex(wallet, i);
+      ids.push(Number(tokenId));
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
+async function scanTransferLogsForIds(wallet: Address) {
+  const ids = new Set<number>();
+  const latest = await getBlockNumber();
+  const toTopics: (Hex | null)[] = [TRANSFER_TOPIC, null, toTopicAddress(wallet)];
+  const fromTopics: (Hex | null)[] = [TRANSFER_TOPIC, toTopicAddress(wallet), null];
+
+  for (const topics of [toTopics, fromTopics]) {
+    let from = START_BLOCK;
+    while (from <= latest) {
+      const to = from + CHUNK_SPAN > latest ? latest : from + CHUNK_SPAN;
+      try {
+        const logs = await getLogs(NONFUNGIBLE_POSITION_MANAGER, from, to, topics);
+        for (const log of logs) {
+          const topic = log.topics?.[3];
+          if (topic) {
+            ids.add(Number(BigInt(topic)));
+          }
+        }
+      } catch {
+        const mid = from + CHUNK_SPAN / 2n;
+        try {
+          const first = await getLogs(NONFUNGIBLE_POSITION_MANAGER, from, mid, topics);
+          const second = await getLogs(NONFUNGIBLE_POSITION_MANAGER, mid + 1n, to, topics);
+          for (const log of [...first, ...second]) {
+            const topic = log.topics?.[3];
+            if (topic) ids.add(Number(BigInt(topic)));
+          }
+        } catch {
+          // ignore and continue
+        }
+      }
+      from = to + 1n;
+    }
+  }
+
+  return [...ids].sort((a, b) => a - b);
+}
+
+async function resolveOwnedTokenIds(wallet: Address, attempts: AttemptLog[]) {
+  const enumerationAttempt: AttemptLog = {
+    step: "enumerate-token-ids",
+    success: false,
+    details: "Attempting ERC-721 enumeration",
+  };
+
+  const viaEnum = await tryEnumerableTokenIds(wallet);
+  if (viaEnum.length > 0) {
+    enumerationAttempt.success = true;
+    enumerationAttempt.details = `Found ${viaEnum.length} tokenIds via enumeration`;
+    attempts.push(enumerationAttempt);
+    return viaEnum;
+  }
+
+  enumerationAttempt.details = "Enumeration failed, falling back to log scan";
+  attempts.push(enumerationAttempt);
+
+  const scanAttempt: AttemptLog = {
+    step: "scan-transfer-logs",
+    success: false,
+    details: `Scanning transfer logs with span ${CHUNK_SPAN}`,
+  };
+
+  const viaLogs = await scanTransferLogsForIds(wallet);
+  if (viaLogs.length > 0) {
+    scanAttempt.success = true;
+    scanAttempt.details = `Recovered ${viaLogs.length} tokenIds from logs`;
+  } else {
+    scanAttempt.error = "No tokenIds recovered from logs";
+  }
+  attempts.push(scanAttempt);
+
+  return viaLogs;
+}
+
+async function resolvePoolAddress(token0: Address, token1: Address, tokenId: number) {
+  const poolFromFarm = await readDepositPool(BigInt(tokenId));
+  if (poolFromFarm) return poolFromFarm;
+  return readPoolByPair(token0, token1);
+}
+
+function toKittenswapPosition(params: {
+  symbol0: string;
+  symbol1: string;
+  decimals0: number;
+  decimals1: number;
+  amount0: number;
+  amount1: number;
+  owed0: bigint;
+  owed1: bigint;
+  tick: number;
+  tokenId: number;
+}) {
+  const { symbol0, symbol1, decimals0, decimals1, amount0, amount1, owed0, owed1, tick, tokenId } = params;
+  const poolName = `${symbol0}/${symbol1} • #${tokenId}`;
+
+  const priceNow = tickToPrice(tick);
+  const baseStable = isStable(symbol0);
+  const quoteStable = isStable(symbol1);
+
+  let totalValueUsd = 0;
+  let accruedFeesUsd: number | undefined;
+
+  if (baseStable) {
+    const owed0Human = Number(formatUnitsClamp(owed0, decimals0));
+    const owed1Human = Number(formatUnitsClamp(owed1, decimals1));
+    const v0 = amount0;
+    const v1 = priceNow > 0 ? amount1 / priceNow : 0;
+    totalValueUsd = v0 + v1;
+    accruedFeesUsd = owed0Human + (priceNow > 0 ? owed1Human / priceNow : 0);
+  } else if (quoteStable) {
+    const owed0Human = Number(formatUnitsClamp(owed0, decimals0));
+    const owed1Human = Number(formatUnitsClamp(owed1, decimals1));
+    const v0 = amount0 * priceNow;
+    const v1 = amount1;
+    totalValueUsd = v0 + v1;
+    accruedFeesUsd = owed0Human * priceNow + owed1Human;
+  }
+
+  return {
+    poolName,
+    totalValueUsd: Number.isFinite(totalValueUsd) && totalValueUsd > 0 ? totalValueUsd : 0,
+    sharePercent: undefined,
+    tokenAmounts: {
+      [symbol0.toUpperCase()]: clampPrecision(amount0),
+      [symbol1.toUpperCase()]: clampPrecision(amount1),
+    },
+    accruedFeesUsd,
+    lastUpdated: new Date().toISOString(),
+  } satisfies KittenswapPosition;
+}
+
+function formatUnitsClamp(value: bigint, decimals: number) {
+  const negative = value < 0n;
+  const bigintValue = negative ? -value : value;
+  const base = 10n ** BigInt(decimals);
+  const whole = bigintValue / base;
+  const fraction = bigintValue % base;
+  const fractionStr = fraction.toString().padStart(decimals, "0").replace(/0+$/, "");
+  const result = `${negative ? "-" : ""}${whole.toString()}${fractionStr ? `.${fractionStr}` : ""}`;
+  return parseFloat(result);
+}
+
+async function resolvePosition(tokenId: number, attempts: AttemptLog[]) {
+  const attempt: AttemptLog = { step: `decode-position-${tokenId}`, success: false };
+  try {
+    const position = await readPositions(BigInt(tokenId));
+    const pool = await resolvePoolAddress(position.token0, position.token1, tokenId);
+    const { currentTick } = await readGlobalState(pool);
+    const [decimals0, decimals1] = await Promise.all([
+      readDecimals(position.token0).catch(() => 18),
+      readDecimals(position.token1).catch(() => 18),
+    ]);
+    const [symbol0, symbol1] = await Promise.all([
+      readSymbol(position.token0).catch(() => "TKN"),
+      readSymbol(position.token1).catch(() => "TKN"),
+    ]);
+
+    const { amount0, amount1 } = amountsFromLiquidity(
+      position.liquidity,
+      currentTick,
+      Math.min(position.tickLower, position.tickUpper),
+      Math.max(position.tickLower, position.tickUpper)
+    );
+
+    attempt.success = true;
+    attempt.details = `${symbol0}/${symbol1} tokenId #${tokenId}`;
+    attempts.push(attempt);
+
+    return toKittenswapPosition({
+      symbol0,
+      symbol1,
+      decimals0,
+      decimals1,
+      amount0,
+      amount1,
+      owed0: position.owed0,
+      owed1: position.owed1,
+      tick: currentTick,
+      tokenId,
+    });
+  } catch (error) {
+    attempt.error = error instanceof Error ? error.message : "Unknown error";
+    attempts.push(attempt);
+    return null;
+  }
+}
+
+export async function fetchOnchainKittenswapPositions(walletAddress: Address) {
+  const attempts: AttemptLog[] = [];
+  const tokenIds = await resolveOwnedTokenIds(walletAddress, attempts);
+
+  if (tokenIds.length === 0) {
+    attempts.push({
+      step: "no-token-ids",
+      success: false,
+      error: `No KittenSwap LP NFTs found for ${walletAddress}`,
+    });
+    return { positions: [], attempts, source: `HyperEVM RPC ${RPC_URL}` };
+  }
+
+  const positions: KittenswapPosition[] = [];
+  for (const tokenId of tokenIds) {
+    const position = await resolvePosition(tokenId, attempts);
+    if (position) {
+      positions.push(position);
+    }
+  }
+
+  if (positions.length === 0) {
+    attempts.push({
+      step: "positions-empty",
+      success: false,
+      error: "Unable to decode any KittenSwap positions",
+    });
+  }
+
+  return { positions, attempts, source: `HyperEVM RPC ${RPC_URL}` };
+}
+
+export function isValidWalletAddress(address: unknown): address is Address {
+  if (typeof address !== "string") {
+    return false;
+  }
+  const trimmed = address.trim();
+  return /^0x[a-fA-F0-9]{40}$/.test(trimmed);
+}


### PR DESCRIPTION
## Summary
- replace the previous Hyperliquid/fallback fetchers with a custom HyperEVM JSON-RPC client that enumerates KittenSwap NFT LPs, decodes token metadata, and normalises balances/fees into dashboard-friendly positions
- tighten the admin dashboard workflow by validating 0x wallet input client-side and returning clearer API errors when the address check fails
- document the new HyperEVM RPC environment knobs in the README and depend on @noble/hashes for Keccak selectors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43fcf03208333a7d90e08ca014576